### PR TITLE
Update default TLS versions used by Cloudfront - Release 5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ supports S3 redirects. This module helps keep setup consistent for multiple Hugo
  - `error_document` - The file that should be served for errors. Default: `404.html`
  - `index_document` - The default file to be served. Default: `index.html`
  - `origin_path` - Path to document root in S3 bucket without slashes. Default: `public`
+ - `origin_ssl_protocols` - List of SSL protocols to enable on Cloudfront distribution. Default: `TLSv1.2_2019` 
  - `routing_rules` - A json array containing routing rules describing redirect behavior and when redirects are applied. Default routes `/` to `index.html` 
  - `viewer_protocol_policy` - One of allow-all, https-only, or redirect-to-https. Default: `redirect-to-https`
  - `cors_allowed_headers` - List of headers allowed in CORS. Default: `[]`

--- a/main.tf
+++ b/main.tf
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "hugo" {
       http_port              = 80
       https_port             = 443
       origin_protocol_policy = "http-only"
-      origin_ssl_protocols   = ["SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"]
+      origin_ssl_protocols   = var.origin_ssl_protocols
     }
 
     // Important to use this format of origin domain name, it is the only format that

--- a/vars.tf
+++ b/vars.tf
@@ -80,7 +80,7 @@ variable "custom_error_response" {
     response_code      = number
     response_page_path = string
   }))
-  default = null
+  default = []
 }
 
 variable "default_root_object" {

--- a/vars.tf
+++ b/vars.tf
@@ -107,6 +107,12 @@ variable "origin_path" {
   default     = "/public"
 }
 
+variable "origin_ssl_protocols" {
+  type        = list(string)
+  description = "List of Origin SSL policies for Cloudfront distribution. See https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValues-security-policy for options"
+  default     = ["TLSv1.2_2019"]
+}
+
 variable "routing_rules" {
   description = "A json array containing routing rules describing redirect behavior and when redirects are applied"
   type        = string


### PR DESCRIPTION
This is a semi-breaking change in that the defaults for `origin_ssl_protocols` is changing from a list of old SSL/TLS versions to only the latest TLS 1.2 version available. A new variable for `origin_ssl_protocols` has been added to allow overriding as needed. 