### PR TITLE
Release 6.0.0 - update to AWS provider version 4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,18 +12,34 @@ data "template_file" "bucket_policy" {
 
 resource "aws_s3_bucket" "hugo" {
   bucket        = var.bucket_name
-  acl           = "public-read"
-  policy        = data.template_file.bucket_policy.rendered
   force_destroy = true
+}
 
-  website {
-    index_document = var.index_document
-    error_document = "${var.origin_path}/${var.error_document}"
+resource "aws_s3_bucket_acl" "hugo" {
+  bucket = aws_s3_bucket.hugo.id
+  acl    = "public-read"
+}
 
-    // Routing rule is needed to support hugo friendly urls
-    routing_rules = var.routing_rules
+resource "aws_s3_bucket_policy" "hugo" {
+  bucket = aws_s3_bucket.hugo.id
+  policy = data.template_file.bucket_policy.rendered
+}
+
+resource "aws_s3_bucket_website_configuration" "hugo" {
+  bucket = aws_s3_bucket.hugo.id
+  index_document {
+    suffix = var.index_document
+  }
+  error_document {
+    key = "${var.origin_path}/${var.error_document}"
   }
 
+  // Routing rule is needed to support hugo friendly urls
+  routing_rules = var.routing_rules
+}
+
+resource "aws_s3_bucket_cors_configuration" "hugo" {
+  bucket = aws_s3_bucket.hugo.id
   cors_rule {
     allowed_headers = var.cors_allowed_headers
     allowed_methods = var.cors_allowed_methods

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,11 @@
 
 terraform {
   required_version = ">= 0.12"
+
+  required_providers {
+    aws = {
+      version = ">= 3.0"
+      source  = "hashicorp/aws"
+    }
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 4.0"
+      version = ">= 4.0, < 5"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 3.0"
+      version = ">= 4.0"
       source  = "hashicorp/aws"
     }
   }


### PR DESCRIPTION
This resolves a deprecation notice for the `acl` and `policy` blocks on `aws_s3_bucket` when using the latest AWS provider version.