### PR TITLE
Release 6.0.2 - Remove deprecated hashicorp/template

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,44 @@
+# This workflow installs the latest version of Terraform CLI. On pull request events, this workflow will run
+# `terraform init`, `terraform fmt`, and `terraform plan`.
+#
+# Documentation for `hashicorp/setup-terraform` is located here: https://github.com/hashicorp/setup-terraform
+
+name: 'Terraform'
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+
+    # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Install the latest version of Terraform CLI
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+
+    # Checks that all Terraform configuration files adhere to a canonical format
+    - name: Terraform Format
+      run: terraform fmt -check -diff -recursive
+
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      run: terraform -chdir=test init
+
+    # Validate the files, referring only to the configuration and not accessing any remote services
+    - name: Terraform Validate
+      run: terraform -chdir=test validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.terraform/

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@
  * Create S3 bucket with appropriate permissions
  */
 locals {
-  bucket_policy = templatefile(file("${path.module}/bucket-policy.json"), {
+  bucket_policy = templatefile("${path.module}/bucket-policy.json", {
     bucket_name         = var.bucket_name
     deployment_user_arn = var.deployment_user_arn
   })

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,11 @@
 /*
  * Create S3 bucket with appropriate permissions
  */
-data "template_file" "bucket_policy" {
-  template = file("${path.module}/bucket-policy.json")
-
-  vars = {
+locals {
+  bucket_policy = templatefile(file("${path.module}/bucket-policy.json"), {
     bucket_name         = var.bucket_name
     deployment_user_arn = var.deployment_user_arn
-  }
+  })
 }
 
 resource "aws_s3_bucket" "hugo" {
@@ -22,7 +20,7 @@ resource "aws_s3_bucket_acl" "hugo" {
 
 resource "aws_s3_bucket_policy" "hugo" {
   bucket = aws_s3_bucket.hugo.id
-  policy = data.template_file.bucket_policy.rendered
+  policy = local.bucket_policy
 }
 
 resource "aws_s3_bucket_website_configuration" "hugo" {

--- a/test/.terraform.lock.hcl
+++ b/test/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = ">= 2.0.0, >= 3.0.0, < 5.0.0"
+  hashes = [
+    "h1:dCRc4GqsyfqHEMjgtlM1EympBcgTmcTkWaJmtd91+KA=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
+  ]
+}

--- a/test/.terraform.lock.hcl
+++ b/test/.terraform.lock.hcl
@@ -23,20 +23,3 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/template" {
-  version = "2.2.0"
-  hashes = [
-    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
-    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
-    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
-    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
-    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
-    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
-    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
-    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
-    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
-    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
-    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
-  ]
-}

--- a/test/main.tf
+++ b/test/main.tf
@@ -1,0 +1,37 @@
+module "simple" {
+  source = "../"
+
+  aliases             = ["www"]
+  bucket_name         = "bucket"
+  cert_domain         = "example.com"
+  deployment_user_arn = "arn:aws:iam::1234567890:user/deploy"
+}
+
+module "full" {
+  source = "../"
+
+  aliases                    = ["www"]
+  aws_region                 = "us-east-1"
+  bucket_name                = "bucket"
+  cert_domain                = "example.com"
+  cf_default_ttl             = "86400"
+  cf_min_ttl                 = "0"
+  cf_max_ttl                 = "31536000"
+  cf_price_class             = "PriceClass_All"
+  cors_allowed_headers       = []
+  cors_allowed_methods       = ["GET"]
+  cors_allowed_origins       = ["https://s3.amazonaws.com"]
+  cors_expose_headers        = []
+  cors_max_age_seconds       = "3000"
+  custom_error_response      = []
+  default_root_object        = "index.html"
+  error_document             = "404.html"
+  index_document             = "index.html"
+  minimum_viewer_tls_version = "TLSv1.2_2019"
+  origin_path                = "/public"
+  origin_ssl_protocols       = ["TLSv1.2"]
+  routing_rules              = "[]"
+  s3_origin_id               = "hugo-s3-origin"
+  viewer_protocol_policy     = "redirect-to-https"
+  deployment_user_arn        = "arn:aws:iam::1234567890:user/deploy"
+}

--- a/test/providers.tf
+++ b/test/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-1"
+}


### PR DESCRIPTION
### Fixed
- Removed use of deprecated hashicorp/template provider.

### Added
- Check syntax using GitHub Actions